### PR TITLE
Add exclusion for short echo tags.

### DIFF
--- a/php.md
+++ b/php.md
@@ -27,6 +27,7 @@ There's a lot of fluff that comes along with all of the PSRs, we recommend makin
 ### Additions
 This is a list of items that we have chosen to follow in addition to the PSRs
 * Use camelCase for methods, functions, properties and variables.
+* Don't use short echo tags. `<?= $variable; ?>` should be `<?php echo $variable; ?>`
 
 
 ### Pay attention to these things


### PR DESCRIPTION
As discussed, we'll avoid using `<?=` in favor of `<?php echo`.  The short echo tags are always available on 5.4, but we should hold off on using them as a whole until our minimal version is greater than 5.4; voting we revisit this later.
